### PR TITLE
Fix priority display bug in interactive mode

### DIFF
--- a/__tests__/priority-display.test.js
+++ b/__tests__/priority-display.test.js
@@ -1,0 +1,139 @@
+/**
+ * 優先度表示のテスト
+ */
+
+const Analyzer = require('../src/analyzer');
+const ConfigManager = require('../src/config');
+
+describe('Analyzer - 優先度表示', () => {
+  let analyzer;
+  let config;
+
+  beforeEach(() => {
+    const configData = {
+      default_browser: 'chromium',
+      timeout_seconds: 60,
+      max_iterations: 10,
+      paths: {
+        logs: './logs',
+        results: './results',
+        test_instructions: './test-instructions',
+        reports: './reports'
+      },
+      testAspectsCSV: './config/test-ViewpointList-simple.csv'
+    };
+    config = new ConfigManager(configData);
+    analyzer = new Analyzer(config);
+  });
+
+  test('未カバー観点の優先度が正しく表示される（High, Medium, Low）', async () => {
+    const executionResults = [];
+    const coverageData = {
+      percentage: 0,
+      covered: 0,
+      total: 10,
+      covered_aspects: [],
+      uncovered_aspects: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    };
+
+    const recommendations = await analyzer.generateRecommendations(
+      executionResults,
+      coverageData
+    );
+
+    // 最大5件の推奨が返される
+    expect(recommendations.length).toBe(5);
+
+    // 最初の2つはHigh
+    expect(recommendations[0].priority).toBe('High');
+    expect(recommendations[0].title).toBe('観点1のテスト');
+    expect(recommendations[1].priority).toBe('High');
+    expect(recommendations[1].title).toBe('観点2のテスト');
+
+    // 次の2つはMedium
+    expect(recommendations[2].priority).toBe('Medium');
+    expect(recommendations[2].title).toBe('観点3のテスト');
+    expect(recommendations[3].priority).toBe('Medium');
+    expect(recommendations[3].title).toBe('観点4のテスト');
+
+    // 残りはLow
+    expect(recommendations[4].priority).toBe('Low');
+    expect(recommendations[4].title).toBe('観点5のテスト');
+  });
+
+  test('失敗したテストと未カバー観点が混在する場合の優先度', async () => {
+    const executionResults = [
+      {
+        test_case_id: 'TC001',
+        aspect_no: 1,
+        success: false,
+        error: { message: 'Element not found' }
+      }
+    ];
+
+    const coverageData = {
+      percentage: 0,
+      covered: 0,
+      total: 10,
+      covered_aspects: [],
+      uncovered_aspects: [2, 3, 4, 5, 6, 7, 8, 9, 10]
+    };
+
+    const recommendations = await analyzer.generateRecommendations(
+      executionResults,
+      coverageData
+    );
+
+    // 最大5件の推奨
+    expect(recommendations.length).toBe(5);
+
+    // 最初は失敗したテスト（常にHigh）
+    expect(recommendations[0].type).toBe('failed');
+    expect(recommendations[0].priority).toBe('High');
+    expect(recommendations[0].title).toContain('失敗したテスト');
+
+    // 残り4件は未カバー観点
+    // 最初の2つ（観点2, 3）はHigh
+    expect(recommendations[1].type).toBe('uncovered');
+    expect(recommendations[1].priority).toBe('High');
+    expect(recommendations[1].title).toBe('観点2のテスト');
+
+    expect(recommendations[2].type).toBe('uncovered');
+    expect(recommendations[2].priority).toBe('High');
+    expect(recommendations[2].title).toBe('観点3のテスト');
+
+    // 次の2つ（観点4, 5）はMedium
+    expect(recommendations[3].type).toBe('uncovered');
+    expect(recommendations[3].priority).toBe('Medium');
+    expect(recommendations[3].title).toBe('観点4のテスト');
+
+    expect(recommendations[4].type).toBe('uncovered');
+    expect(recommendations[4].priority).toBe('Medium');
+    expect(recommendations[4].title).toBe('観点5のテスト');
+  });
+
+  test('未カバー観点が2つだけの場合は両方High', async () => {
+    const executionResults = [];
+    const coverageData = {
+      percentage: 80,
+      covered: 8,
+      total: 10,
+      covered_aspects: [1, 2, 3, 4, 5, 6, 7, 8],
+      uncovered_aspects: [9, 10]
+    };
+
+    const recommendations = await analyzer.generateRecommendations(
+      executionResults,
+      coverageData
+    );
+
+    expect(recommendations.length).toBe(2);
+
+    // 両方High（最初の2つなので）
+    expect(recommendations[0].priority).toBe('High');
+    expect(recommendations[0].title).toBe('観点9のテスト');
+
+    expect(recommendations[1].priority).toBe('High');
+    expect(recommendations[1].title).toBe('観点10のテスト');
+  });
+});

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -404,14 +404,26 @@ class Analyzer {
     
     // 2. 未カバー観点から推奨を生成（失敗テストと合わせて最大5件まで）
     const remainingSlots = maxRecommendations - recommendations.length;
-    
+
     if (remainingSlots > 0 && coverageData.uncovered_aspects && coverageData.uncovered_aspects.length > 0) {
       const uncoveredAspects = coverageData.uncovered_aspects.slice(0, remainingSlots);
-      
-      for (const aspectId of uncoveredAspects) {
+
+      for (let i = 0; i < uncoveredAspects.length; i++) {
+        const aspectId = uncoveredAspects[i];
+
+        // 優先度を動的に設定
+        let priority;
+        if (i < 2) {
+          priority = 'High';   // 最初の2つは高優先度
+        } else if (i < 4) {
+          priority = 'Medium'; // 次の2つは中優先度
+        } else {
+          priority = 'Low';    // 残りは低優先度
+        }
+
         recommendations.push({
           type: 'uncovered',
-          priority: 'High',
+          priority: priority,
           title: `観点${aspectId}のテスト`,
           reason: `未カバー観点: 観点${aspectId}`,
           aspectId: aspectId


### PR DESCRIPTION
問題:
- 対話モードで推奨テストの優先度がすべて「High」と表示される
- 未カバー観点の優先度が固定値になっていた

修正内容:
- src/analyzer.jsのgenerateRecommendations関数を修正
- 未カバー観点の優先度を動的に設定するように変更
  - 最初の2つ: High
  - 次の2つ: Medium
  - 残り: Low

テスト:
- __tests__/priority-display.test.jsを追加
- 優先度の動的割り当てをテストで検証
- 既存のテストも全てパス