### PR TITLE
feat: Android Chromeブラウザサポートを追加

### DIFF
--- a/PLAYWRIGHT_MCP_SETUP.md
+++ b/PLAYWRIGHT_MCP_SETUP.md
@@ -151,6 +151,21 @@ npx @playwright/mcp@latest --headless --port 8931
 
 **結果**: ✅ 設定ファイル作成済み
 
+### テスト4: Android Chromeプロジェクト設定
+
+**設定ファイル**: `playwright.config.js`
+**プロジェクト**:
+- `android-chrome-pixel5`: Pixel 5エミュレーション
+- `android-chrome-pixel4`: Pixel 4エミュレーション
+- `android-chrome-galaxy-s9`: Galaxy S9+エミュレーション
+
+**実行方法**:
+```bash
+npx playwright test --project=android-chrome-pixel5
+```
+
+**結果**: ✅ Android Chromeプロジェクト設定済み
+
 ---
 
 ## 🚀 次のステップ
@@ -237,6 +252,7 @@ MCP APIからの応答をOthello形式に変換：
 - [x] **Playwright MCP (`@playwright/mcp@0.0.42`) インストール済み** ← NEW!
 - [x] VS Code MCP設定 (`.vscode/settings.json`) 作成済み
 - [x] スタンドアロンモード動作確認済み
+- [x] **Android Chromeブラウザプロジェクト設定 (`playwright.config.js`)** ← NEW!
 - [ ] OthelloとMCPの統合実装（次のフェーズ）
 
 ---

--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ npx @playwright/mcp@latest --browser chromium
 
 > **補足**: 初回実行時にはPlaywrightがブラウザモジュールをダウンロードするため時間がかかる場合があります。
 
+#### Android Chromeブラウザでのテスト実行
+
+OthelloはAndroid Chromeブラウザに対応しています。テスト実行時に以下のプロジェクト名を指定することで、Android端末のエミュレーションでテストを実行できます：
+
+- `android-chrome-pixel5`: Pixel 5のエミュレーション
+- `android-chrome-pixel4`: Pixel 4のエミュレーション
+- `android-chrome-galaxy-s9`: Galaxy S9+のエミュレーション
+
+**実行例**：
+```bash
+npx playwright test --project=android-chrome-pixel5
+```
+
+これらのプロジェクトは `playwright.config.js` に定義されており、モバイルビューポート、タッチスクリーン、ユーザーエージェントなどがAndroidデバイスに合わせて自動設定されます。
+
 #### Playwrightログイン状態のブートストラップをカスタマイズする環境変数
 
 MFAを含む手動ログインでセッションを保存する `scripts/login_setup.ts` は、以下の環境変数で挙動を上書きできます（デフォルトはローカル開発向け）：

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -53,6 +53,29 @@ module.exports = defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
 
+    // Android Chrome（複数のデバイスプロファイル）
+    {
+      name: 'android-chrome-pixel5',
+      use: {
+        ...devices['Pixel 5'],
+        browserName: 'chromium',
+      },
+    },
+    {
+      name: 'android-chrome-pixel4',
+      use: {
+        ...devices['Pixel 4'],
+        browserName: 'chromium',
+      },
+    },
+    {
+      name: 'android-chrome-galaxy-s9',
+      use: {
+        ...devices['Galaxy S9+'],
+        browserName: 'chromium',
+      },
+    },
+
     // 必要に応じて追加のブラウザを有効化
     // {
     //   name: 'firefox',


### PR DESCRIPTION
playwright.config.jsに3つのAndroid Chromeプロジェクトを追加:
- android-chrome-pixel5: Pixel 5エミュレーション
- android-chrome-pixel4: Pixel 4エミュレーション
- android-chrome-galaxy-s9: Galaxy S9+エミュレーション

各プロジェクトはPlaywrightの組み込みデバイスプロファイルを使用し、
モバイルビューポート、タッチスクリーン、ユーザーエージェントを
自動設定します。

ドキュメント更新:
- README.md: Android Chrome実行方法を追加
- PLAYWRIGHT_MCP_SETUP.md: テスト確認とチェックリストを更新